### PR TITLE
Adds http endpoints for reading, shutdown and ping

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,30 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/gobuffalo/packr"
+  packages = ["."]
+  revision = "6434a292ac52e6964adebfdce3f9ce6d9f16be01"
+  version = "v1.10.4"
+
+[[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/gorilla/handlers"
+  packages = ["."]
+  revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
+  version = "v1.3.0"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
+  version = "v1.6.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
@@ -18,6 +42,12 @@
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -76,6 +106,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "76608de7ed12ccea1b7f20f16666edc1933e9359d975397667c4126808741044"
+  inputs-digest = "0125a178b0a03f0eb45f531721c664ddca4bf81f448211d96117fe6328554a09"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ I can't say for sure, but I decided to implement the sensors as io.Reader where 
 # Hardware
 
 The supported/tested sensors are:
+* Dummy (returns a random temperature, humidity, and pressure)
 * [Adafruit BME280 sensors](https://www.adafruit.com/product/2652)
 * [Adafruit SHT31-D sensors](https://www.adafruit.com/product/2857)
 

--- a/index.go
+++ b/index.go
@@ -1,0 +1,60 @@
+package main
+
+var IndexHTML = `
+<html>
+  <head>
+    <title>Airmeter</title>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+  </head>
+  
+  <body>
+      <div class="container-fluid">
+        <nav class="navbar navbar-dark bg-dark">
+            <a class="navbar-brand" href="#">
+              <i class="fas fa-thermometer-empty"></i> Airmeter
+            </a>
+          </nav>
+        <div class="row justify-content-center">
+          <div class="col text-center">
+            <ul class="list-group" id="reading"></ul>
+          </div>
+        </div>
+      </div>
+      <nav class="navbar fixed-bottom navbar-dark bg-dark"></nav>
+  </body>
+
+  <script type="text/javascript">
+    var endpoint = window.location.protocol + '//' + window.location.host + '/api/reading';
+    function getReading(endpoint) {
+        (function (endpoint) {
+          var startTime = new Date().getTime();
+          console.log(startTime + ": Getting information from " + endpoint);
+          $.ajax({
+            type: "GET",
+            url: endpoint,
+            timeout: 3000,
+            success: function(data){
+              total = new Date().getTime()-startTime;
+              console.log(name + " start time: " + startTime + " |Total time: "+ total);
+              for (var item in data) {
+                $('#reading').append('<li class="list-group-item list-group-item-success display-4">' + item + ' : ' + data[item] + ' (' + total + 'ms)</li>')
+              }
+            },
+            error: function(){
+              total = new Date().getTime()-startTime;
+              console.log("Failed to get information from " + endpoint);
+            }
+          });
+        })(endpoint);
+    };
+
+    $(document).ready(function(){
+        getReading(endpoint);
+    });
+  </script>
+</html>
+`

--- a/main.go
+++ b/main.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"sync"
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/fishnix/airmeter/sensor"
+	"github.com/gobuffalo/packr"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 
@@ -22,11 +26,13 @@ var (
 	version = "0.2.0"
 
 	vers         = flag.Bool("v", false, "display version information and exit")
-	sensorDriver = flag.String("d", "bme280", "Which sensor driver to use: 'bme280' or 'sht3x'")
+	sensorDriver = flag.String("d", "bme280", "Which sensor driver to use: 'dummy', 'bme280' or 'sht3x'")
 
 	frequency  = flag.String("f", "5s", "frequency to collect data from the sensor")
 	location   = flag.String("l", "home", "location for the sensor")
 	mqttBroker = flag.String("b", "tcp://iot.eclipse.org:1883", "MQTT broker endpoint")
+
+	httpAddress = flag.String("a", ":8000", "HTTP listen address")
 
 	// Advanced options
 	topicroot       = flag.String("t", "airmeter", "Advanced: Set the MQTT topic root - the topic will be 'topicroot/location' - ")
@@ -41,12 +47,19 @@ var publishHandler MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Messa
 	fmt.Printf("MSG: %s\n", msg.Payload())
 }
 
+// CommandRequest defines a command request recieved over the API
+type CommandRequest struct {
+	name string
+	args map[string]string
+}
+
 type job struct {
-	ticker     *time.Ticker
-	waitgroup  *sync.WaitGroup
-	sensor     io.Reader
-	mqttTopic  string
-	mqttClient MQTT.Client
+	ticker         *time.Ticker
+	waitgroup      *sync.WaitGroup
+	sensor         io.Reader
+	mqttTopic      string
+	mqttClient     MQTT.Client
+	requestChannel chan *CommandRequest
 }
 
 func main() {
@@ -84,35 +97,133 @@ func main() {
 	defer cancel()
 
 	var wg sync.WaitGroup
+	cmdChan := make(chan *CommandRequest)
 	wg.Add(1)
-	Start(ctx, job{
-		ticker:     time.NewTicker(freq),
-		waitgroup:  &wg,
-		sensor:     sensor,
-		mqttTopic:  topic,
-		mqttClient: mqttClient,
+	respChan := Start(ctx, cancel, job{
+		ticker:         time.NewTicker(freq),
+		waitgroup:      &wg,
+		sensor:         sensor,
+		mqttTopic:      topic,
+		mqttClient:     mqttClient,
+		requestChannel: cmdChan,
 	})
+
+	StartHTTP(ctx, cmdChan, respChan)
+	log.Info("Waiting for threads to exit")
 	wg.Wait()
 
 	mqttClient.Disconnect(1)
 }
 
-func Start(ctx context.Context, j job) {
+// Start begins reading the sensor data and writing it to MQTT
+func Start(ctx context.Context, cancel context.CancelFunc, j job) chan []byte {
+	responseChannel := make(chan []byte)
 	go func() {
 		defer j.waitgroup.Done()
 		for {
 			select {
 			case <-j.ticker.C:
+				log.Debug("Reading from sensor and writing to MQTT")
 				b, e := ioutil.ReadAll(j.sensor)
 				if e != nil {
-					log.Fatalln(e)
+					log.Errorf("%s", e)
+				} else {
+					token := j.mqttClient.Publish(j.mqttTopic, 0, false, string(b))
+					token.Wait()
 				}
-				token := j.mqttClient.Publish(j.mqttTopic, 0, false, string(b))
-				token.Wait()
+			case cmd := <-j.requestChannel:
+				log.Debugf("Got a request on the command request channel: %s", cmd.name)
+				switch cmd.name {
+				case "shutdown":
+					log.Warn("Got request to shutdown.")
+					cancel()
+					return
+				case "reading":
+					log.Info("Got request for reading.")
+					b, e := ioutil.ReadAll(j.sensor)
+					if e != nil {
+						log.Errorf("%s", e)
+					} else {
+						responseChannel <- b
+					}
+				default:
+					log.Errorf("Got unrecognized command on command request channel: %s", cmd.name)
+				}
 			case <-ctx.Done():
-				log.Info("Shutdown...")
+				log.Warn("Shutdown...")
 				return
 			}
+		}
+	}()
+	return responseChannel
+}
+
+// StartHTTP starts the HTTP subsystem
+func StartHTTP(ctx context.Context, cmdChan chan *CommandRequest, respChan chan []byte) {
+	// set up a new box by giving it a (relative) path to a folder on disk:
+	box := packr.NewBox("./static")
+	indexHTML, err := box.MustBytes("index.html")
+	if err != nil {
+		log.Fatal("Couldn't read static file for build")
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(indexHTML)
+	})
+
+	api := r.PathPrefix("/api").Subrouter()
+	api.HandleFunc("/{cmd}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		switch vars["cmd"] {
+		case "shutdown":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			cmdChan <- &CommandRequest{name: "shutdown"}
+		case "reading":
+			if r.Method != http.MethodGet {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			timeout := time.After(30 * time.Second)
+			cmdChan <- &CommandRequest{name: "reading"}
+
+			select {
+			case <-timeout:
+				w.WriteHeader(http.StatusRequestTimeout)
+				return
+			case reading, ok := <-respChan:
+				if !ok {
+					log.Error("Response channel closed")
+					w.WriteHeader(http.StatusRequestTimeout)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(reading)
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+
+	headersOk := handlers.AllowedHeaders([]string{"X-Requested-With", "Auth-Token"})
+	originsOk := handlers.AllowedOrigins([]string{"*"})
+	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "OPTIONS"})
+	srv := &http.Server{
+		Handler:      handlers.CORS(originsOk, headersOk, methodsOk)(handlers.LoggingHandler(os.Stdout, r)),
+		Addr:         *httpAddress,
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+
+	log.Infof("Starting HTTP server on %s", *httpAddress)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			log.Fatal(err)
 		}
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/fishnix/airmeter/sensor"
-	"github.com/gobuffalo/packr"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	uuid "github.com/satori/go.uuid"
@@ -160,17 +159,10 @@ func Start(ctx context.Context, cancel context.CancelFunc, j job) chan []byte {
 
 // StartHTTP starts the HTTP subsystem
 func StartHTTP(ctx context.Context, cmdChan chan *CommandRequest, respChan chan []byte) {
-	// set up a new box by giving it a (relative) path to a folder on disk:
-	box := packr.NewBox("./static")
-	indexHTML, err := box.MustBytes("index.html")
-	if err != nil {
-		log.Fatal("Couldn't read static file for build")
-	}
-
 	r := mux.NewRouter()
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write(indexHTML)
+		w.Write([]byte(IndexHTML))
 	})
 
 	api := r.PathPrefix("/api").Subrouter()

--- a/sensor/bme280.go
+++ b/sensor/bme280.go
@@ -1,0 +1,69 @@
+package sensor
+
+import (
+	"encoding/json"
+	"io"
+
+	"gobot.io/x/gobot/drivers/i2c"
+)
+
+// BME280Sensor is a wrapper for the BME280 sensor drivers
+type BME280Sensor struct {
+	Driver  *i2c.BME280Driver
+	Current Reading
+}
+
+// NewBME280Sensor returns a BME280Sensor
+func NewBME280Sensor(adapter i2c.Connector) BME280Sensor {
+	return BME280Sensor{Driver: i2c.NewBME280Driver(adapter)}
+}
+
+// Read gets the data from the sensor.  It implements io.Reader by filling the []byte with
+// the Reading struct encoded as JSON.  Every successful call returns io.EOF.
+func (sensor BME280Sensor) Read(p []byte) (int, error) {
+	sensor.Driver.Start()
+
+	// read the humidity from the sensor
+	hum, err := sensor.Driver.Humidity()
+	if err != nil {
+		return 0, err
+	}
+
+	// read the temperature from the sensor
+	tem, err := sensor.Driver.Temperature()
+	if err != nil {
+		return 0, err
+	}
+
+	// read the pressure from the sensor
+	prs, err := sensor.Driver.Pressure()
+	if err != nil {
+		return 0, err
+	}
+
+	// not exactly sure how to set the constant for sea level pressure and don't want to
+	// copy-pasta the calculation here since my altitude wont change so its not very useful
+	// i2c.bmp280SeaLevelPressure = 103400.00
+	// alt, err := s.Driver.Altitude()
+	// if err != nil {
+	// 	return err
+	// }
+
+	sensor.Current = Reading{
+		Temperature: tem,
+		Humidity:    hum,
+		Pressure:    prs,
+	}
+
+	j, err := json.Marshal(sensor.Current)
+	if err != nil {
+		return 0, err
+	}
+
+	// fill the slice of bytes from the values marshaled to JSON
+	for i, b := range j {
+		p[i] = b
+	}
+
+	return len(j), io.EOF
+}

--- a/sensor/dummy.go
+++ b/sensor/dummy.go
@@ -1,0 +1,39 @@
+package sensor
+
+import (
+	"encoding/json"
+	"io"
+	"math/rand"
+
+	"gobot.io/x/gobot/drivers/i2c"
+)
+
+// DummySensor is a "wrapper" for a dummy sensor drivers
+type DummySensor struct {
+	Current Reading
+}
+
+// NewDummySensor returns a DummySensor
+func NewDummySensor(_ i2c.Connector) DummySensor {
+	return DummySensor{}
+}
+
+func (sensor DummySensor) Read(p []byte) (int, error) {
+	sensor.Current = Reading{
+		Temperature: rand.Float32() * 100,
+		Humidity:    rand.Float32() * 100,
+		Pressure:    rand.Float32() * 100,
+	}
+
+	j, err := json.Marshal(sensor.Current)
+	if err != nil {
+		return 0, err
+	}
+
+	// fill the slice of bytes from the values marshaled to JSON
+	for i, b := range j {
+		p[i] = b
+	}
+
+	return len(j), io.EOF
+}

--- a/sensor/sensor.go
+++ b/sensor/sensor.go
@@ -1,7 +1,6 @@
 package sensor
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -25,105 +24,9 @@ func NewAirMeterReader(adapter i2c.Connector, driver string) (io.Reader, error) 
 		return NewBME280Sensor(adapter), nil
 	case "sht3x":
 		return NewSHT3xSensor(adapter), nil
+	case "dummy":
+		return NewDummySensor(nil), nil
 	default:
 		return nil, fmt.Errorf("Invalid driver '%s' or adapter", driver)
 	}
-}
-
-// BME280Sensor is a wrapper for the BME280 sensor drivers
-type BME280Sensor struct {
-	Driver  *i2c.BME280Driver
-	Current Reading
-}
-
-// NewBME280Sensor returns a BME280Sensor
-func NewBME280Sensor(adapter i2c.Connector) BME280Sensor {
-	return BME280Sensor{Driver: i2c.NewBME280Driver(adapter)}
-}
-
-// Read gets the data from the sensor.  It implements io.Reader by filling the []byte with
-// the Reading struct encoded as JSON.  Every successful call returns io.EOF.
-func (sensor BME280Sensor) Read(p []byte) (int, error) {
-	sensor.Driver.Start()
-
-	// read the humidity from the sensor
-	hum, err := sensor.Driver.Humidity()
-	if err != nil {
-		return 0, err
-	}
-
-	// read the temperature from the sensor
-	tem, err := sensor.Driver.Temperature()
-	if err != nil {
-		return 0, err
-	}
-
-	// read the pressure from the sensor
-	prs, err := sensor.Driver.Pressure()
-	if err != nil {
-		return 0, err
-	}
-
-	// not exactly sure how to set the constant for sea level pressure and don't want to
-	// copy-pasta the calculation here since my altitude wont change so its not very useful
-	// i2c.bmp280SeaLevelPressure = 103400.00
-	// alt, err := s.Driver.Altitude()
-	// if err != nil {
-	// 	return err
-	// }
-
-	sensor.Current = Reading{
-		Temperature: tem,
-		Humidity:    hum,
-		Pressure:    prs,
-	}
-
-	j, err := json.Marshal(sensor.Current)
-	if err != nil {
-		return 0, err
-	}
-
-	// fill the slice of bytes from the values marshaled to JSON
-	for i, b := range j {
-		p[i] = b
-	}
-
-	return len(j), io.EOF
-}
-
-// SHT3xSensor is a wrapper for the SHT3x sensor drivers
-type SHT3xSensor struct {
-	Driver  *i2c.SHT3xDriver
-	Current Reading
-}
-
-// NewSHT3xSensor returns a SHT3xSensor
-func NewSHT3xSensor(adapter i2c.Connector) SHT3xSensor {
-	return SHT3xSensor{Driver: i2c.NewSHT3xDriver(adapter)}
-}
-
-func (sensor SHT3xSensor) Read(p []byte) (int, error) {
-	sensor.Driver.Start()
-
-	tem, hum, err := sensor.Driver.Sample()
-	if err != nil {
-		return 0, err
-	}
-
-	sensor.Current = Reading{
-		Temperature: tem,
-		Humidity:    hum,
-	}
-
-	j, err := json.Marshal(sensor.Current)
-	if err != nil {
-		return 0, err
-	}
-
-	// fill the slice of bytes from the values marshaled to JSON
-	for i, b := range j {
-		p[i] = b
-	}
-
-	return len(j), io.EOF
 }

--- a/sensor/sht3x.go
+++ b/sensor/sht3x.go
@@ -1,0 +1,45 @@
+package sensor
+
+import (
+	"encoding/json"
+	"io"
+
+	"gobot.io/x/gobot/drivers/i2c"
+)
+
+// SHT3xSensor is a wrapper for the SHT3x sensor drivers
+type SHT3xSensor struct {
+	Driver  *i2c.SHT3xDriver
+	Current Reading
+}
+
+// NewSHT3xSensor returns a SHT3xSensor
+func NewSHT3xSensor(adapter i2c.Connector) SHT3xSensor {
+	return SHT3xSensor{Driver: i2c.NewSHT3xDriver(adapter)}
+}
+
+func (sensor SHT3xSensor) Read(p []byte) (int, error) {
+	sensor.Driver.Start()
+
+	tem, hum, err := sensor.Driver.Sample()
+	if err != nil {
+		return 0, err
+	}
+
+	sensor.Current = Reading{
+		Temperature: tem,
+		Humidity:    hum,
+	}
+
+	j, err := json.Marshal(sensor.Current)
+	if err != nil {
+		return 0, err
+	}
+
+	// fill the slice of bytes from the values marshaled to JSON
+	for i, b := range j {
+		p[i] = b
+	}
+
+	return len(j), io.EOF
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,56 @@
+<html>
+  <head>
+    <title>Airmeter</title>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+  </head>
+  
+  <body>
+      <div class="container-fluid">
+        <nav class="navbar navbar-dark bg-dark">
+            <a class="navbar-brand" href="#">
+              <i class="fas fa-thermometer-empty"></i> Airmeter
+            </a>
+          </nav>
+        <div class="row justify-content-center">
+          <div class="col text-center">
+            <ul class="list-group" id="reading"></ul>
+          </div>
+        </div>
+      </div>
+      <nav class="navbar fixed-bottom navbar-dark bg-dark"></nav>
+  </body>
+
+  <script type="text/javascript">
+    var endpoint = window.location.protocol + '//' + window.location.host + '/api/reading';
+    function getReading(endpoint) {
+        (function (endpoint) {
+          var startTime = new Date().getTime();
+          console.log(startTime + ": Getting information from " + endpoint);
+          $.ajax({
+            type: "GET",
+            url: endpoint,
+            timeout: 3000,
+            success: function(data){
+              total = new Date().getTime()-startTime;
+              console.log(name + " start time: " + startTime + " |Total time: "+ total);
+              for (var item in data) {
+                $('#reading').append('<li class="list-group-item list-group-item-success display-4">' + item + ' : ' + data[item] + ' (' + total + 'ms)</li>')
+              }
+            },
+            error: function(){
+              total = new Date().getTime()-startTime;
+              console.log("Failed to get information from " + endpoint);
+            }
+          });
+        })(endpoint);
+    };
+
+    $(document).ready(function(){
+        getReading(endpoint);
+    });
+  </script>
+</html>


### PR DESCRIPTION
Exposes readings via /api endpoints and bundles a static index.html with the binary for simple reading
via a browser.  Splits the sensors into their own files for simpler maintenance and adding more sensors.  Adds a dummy sensor for developing and testing.